### PR TITLE
Disable Linux sandbox for brew install --build-from-source

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -37,6 +37,7 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         env:
           HOMEBREW_DEVELOPER: "true"
+          HOMEBREW_NO_SANDBOX_LINUX: "1"
         run: |
           NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           echo >> /home/runner/.bashrc

--- a/.github/workflows/diff-test.yml
+++ b/.github/workflows/diff-test.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_DEVELOPER: "true"
+          HOMEBREW_NO_SANDBOX_LINUX: "1"
         run: |
           git fetch origin master
           differs=$(git diff origin/master --name-only | grep '\.rb$' || true)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_DEVELOPER: "true"
+          HOMEBREW_NO_SANDBOX_LINUX: "1"
         run: |
           failed=""
           for file in *.rb; do

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ update-all:
 	done
 
 test/%:
-	HOMEBREW_DEVELOPER=true brew install --build-from-source $*
+	HOMEBREW_DEVELOPER=true HOMEBREW_NO_SANDBOX_LINUX=1 brew install --build-from-source $*


### PR DESCRIPTION
## Summary
- Homebrew now requires `bubblewrap` (`bwrap`) to sandbox builds on Linux, which is not available on the local environment or GitHub-hosted runners. This caused `brew install --build-from-source` to fail with `Error: Bubblewrap is required to use the Linux sandbox but was not found.`
- Set `HOMEBREW_NO_SANDBOX_LINUX=1` in the `Makefile` (`test/%` target) and in `test.yml`, `diff-test.yml`, and `daily.yml` to disable the Linux sandbox. The variable is Linux-specific and is ignored on macOS runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)